### PR TITLE
Update standard.yaml

### DIFF
--- a/config/standard.yaml
+++ b/config/standard.yaml
@@ -25,6 +25,7 @@ rules:
     space-before-blocks             : [off]
     no-multiple-empty-lines         : [off]
     no-multi-spaces                 : [off]
+    no-trailing-spaces              : [off]
     keyword-spacing                 : [off]
     key-spacing                     : [off]
     comma-spacing                   : [off]


### PR DESCRIPTION
WebStorm likes to fill trailing spaces when enter a newline.
